### PR TITLE
Fix write_stream for mini-FAT (small) streams — decryption of small .doc panics

### DIFF
--- a/src/ole.rs
+++ b/src/ole.rs
@@ -221,6 +221,13 @@ impl OleFile {
 
         validate!(data.len() == stream_size as usize, InvalidStructure)?;
 
+        // Streams smaller than the cutoff live in the mini-FAT (packed inside the
+        // root ministream), not directly in the main FAT. Writing them through the
+        // main-FAT path computes bogus offsets, so route them separately.
+        if stream_size < self.header.mini_stream_cutoff_size as u64 {
+            return self.write_mini_stream(start_sector, data);
+        }
+
         // Write data sector by sector, following the FAT
         let nb_sectors = ((stream_size + self.sector_size as u64 - 1) / self.sector_size as u64) as usize;
         let mut sect = start_sector;
@@ -242,6 +249,63 @@ impl OleFile {
 
             data_offset += bytes_to_write;
             sect = self.fat[sect as usize];
+        }
+
+        Ok(())
+    }
+
+    /// Write `data` into a stream stored in the mini-FAT.
+    ///
+    /// Mini streams are packed into the root entry's "ministream", which is itself
+    /// an ordinary main-FAT stream. So each mini-sector maps to a byte range inside
+    /// the ministream, which in turn maps to a physical offset in `self.raw` via the
+    /// ministream's own main-FAT sector chain. `mini_sector_size` (64) always divides
+    /// `sector_size` (512), so a mini-sector never straddles two physical sectors.
+    fn write_mini_stream(&mut self, start_mini_sector: u32, data: &[u8]) -> Result<(), DecryptError> {
+        // The mini-FAT and ministream are loaded lazily when a small stream is first
+        // opened; decrypt paths always read before writing, but load defensively.
+        if self.ministream.is_none() {
+            self.load_minifat()?;
+            let size_ministream = self.direntries[self.root_sid].size;
+            self.ministream = Some(self.open_helper(
+                self.direntries[self.root_sid].packed.isect_start,
+                size_ministream,
+                true,
+            )?);
+        }
+
+        // Walk the ministream's own main-FAT chain once so mini-sector -> physical
+        // offset is a simple lookup.
+        let mut container_sectors: Vec<u32> = Vec::new();
+        let mut sect = self.direntries[self.root_sid].packed.isect_start;
+        while sect != ENDOFCHAIN && sect != FREESECT {
+            container_sectors.push(sect);
+            sect = *self.fat.get(sect as usize).ok_or(InvalidStructure)?;
+        }
+
+        let mini = self.mini_sector_size as usize;
+        let sector_size = self.sector_size as usize;
+        let mut mini_sect = start_mini_sector;
+        let mut data_offset = 0usize;
+
+        while mini_sect != ENDOFCHAIN && mini_sect != FREESECT && data_offset < data.len() {
+            let ministream_byte = mini_sect as usize * mini;
+            let sector_ord = ministream_byte / sector_size;
+            let off_in_sect = ministream_byte % sector_size;
+
+            let phys = *container_sectors
+                .get(sector_ord)
+                .ok_or(InvalidStructure)?;
+            let file_offset = (phys as usize + 1) * sector_size + off_in_sect;
+
+            let bytes_to_write = std::cmp::min(mini, data.len() - data_offset);
+            validate!(file_offset + bytes_to_write <= self.raw.len(), InvalidStructure)?;
+
+            self.raw[file_offset..(file_offset + bytes_to_write)]
+                .copy_from_slice(&data[data_offset..(data_offset + bytes_to_write)]);
+
+            data_offset += bytes_to_write;
+            mini_sect = *self.minifat.get(mini_sect as usize).ok_or(InvalidStructure)?;
         }
 
         Ok(())


### PR DESCRIPTION
### Problem

`decrypt_from_file` panics with a slice-out-of-range on small legacy `.doc` files. For example, decrypting a compact Word 97–2003 document (RC4 CryptoAPI) whose `WordDocument`, table and `Data` streams are each under the 4096-byte mini-stream cutoff:

```
thread '...' panicked at src/ole.rs:240:
range start index 29696 out of range for slice of length 10240
```

### Cause

OLE streams smaller than `mini_stream_cutoff_size` (4096) aren't stored directly in the main FAT — they live inside the root entry's *ministream*, addressed by the mini-FAT in 64-byte mini-sectors. `write_stream()` only handled the main-FAT case, computing every physical offset as `(sector + 1) * sector_size`. For a mini-stream those sector indices are mini-FAT indices, so the offsets land far outside the file and the write-back in `decrypt_doc97()` panics.

`open_stream()` already handles mini streams correctly on the read side (via `open_helper`); only the write side was missing.

### Fix

Add `write_mini_stream()`, mirroring the read path: ensure the mini-FAT/ministream are loaded, walk the root ministream's own main-FAT chain once, then map each mini-sector to a physical offset. `mini_sector_size` always divides `sector_size`, so a mini-sector never straddles a physical sector, keeping the mapping a simple lookup. `write_stream()` routes any stream under the cutoff through it; larger streams are unchanged. All lookups are bounds-checked and return `InvalidStructure` rather than panicking.

### Testing
- `cargo build` / `cargo test` pass.
- Verified end-to-end against a real RC4-CryptoAPI-encrypted `.doc` (password-protected, ~10 KB): before this change `decrypt_from_file` panics; after it, decryption succeeds and the plaintext OLE document parses correctly. OOXML and larger `.doc` files are unaffected.